### PR TITLE
Updates underline to use `ins` tag (via `++`)

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -318,7 +318,7 @@ export function addInlineStyleMarkdown(style: string, content: string): string {
   } else if (style === 'ITALIC') {
     return `*${content}*`;
   } else if (style === 'UNDERLINE') {
-    return `__${content}__`;
+    return `++${content}++`;
   } else if (style === 'STRIKETHROUGH') {
     return `~~${content}~~`;
   } else if (style === 'CODE') {

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Following is the list of conversions it supports:
 
 2. Ordered and unordered list blocks with depths are appended with 4 blank spaces.
 
-3. Converts inline styles BOLD, ITALIC, UNDERLINE, STRIKETHROUGH, CODE, SUPERSCRIPT, SUBSCRIPT to corresponding markdown syntax: `**, *, __, ~~, ``, <sup>, <sub>`.
+3. Converts inline styles BOLD, ITALIC, UNDERLINE, STRIKETHROUGH, CODE, SUPERSCRIPT, SUBSCRIPT to corresponding markdown syntax: `**, *, ++, ~~, ``, <sup>, <sub>`.
 
 4. Converts inline styles color, background-color, font-size, font-family to a span tag with inline style details:
 `<span style="color:xyz;font-size:xx">`. The inline styles should start with strings `color` or `font-size` like `color-red`, `color-green` or `fontsize-12`, `fontsize-20`.


### PR DESCRIPTION
Markdown will underline `ins` text by default, and bolds `__`.