### PR TITLE
Fix issue where if you do shift+enter \s\s will appear on your text

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -293,8 +293,6 @@ function getSectionText(text: Array<string>): string {
   if (text && text.length > 0) {
     const chars = text.map((ch) => {
       switch (ch) {
-        case '\n':
-          return '\\s\\s\n';
         case '&':
           return '&amp;';
         case '<':


### PR DESCRIPTION
This will fix the issue that if you hit `shift+enter` it will return `\s\s` in your text and won't break the line.

Draftjs recognise if you do `enter` or `shift+enter` as a new line already.